### PR TITLE
fix(tabs): add support for react-hot-loader by comparing cached rende…

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -8,6 +8,9 @@ import InjectTab from './Tab.js';
 import InjectTabContent from './TabContent.js';
 
 const factory = (Tab, TabContent, FontIcon) => {
+  const TabType = <Tab />.type;
+  const TabContentType = <TabContent />.type;
+
   class Tabs extends Component {
     static propTypes = {
       children: PropTypes.node,
@@ -115,12 +118,12 @@ const factory = (Tab, TabContent, FontIcon) => {
       const contents = [];
 
       React.Children.forEach(this.props.children, (item) => {
-        if (item.type === Tab) {
+        if (item.type === TabType) {
           headers.push(item);
           if (item.props.children) {
             contents.push(<TabContent children={item.props.children} theme={this.props.theme} />);
           }
-        } else if (item.type === TabContent) {
+        } else if (item.type === TabContentType) {
           contents.push(item);
         }
       });


### PR DESCRIPTION
Encountered a strange bug when migrating to React 16 as all my tabs where not properly rendering anymore. Quite painful to debug but the culprit was [react-hot-loader@^4.3.3](https://github.com/gaearon/react-hot-loader) that was proxying components that would ultimately fail some reference equality test in the tabs inner code.

Looks like it's a [recurring issue](https://github.com/gaearon/react-hot-loader#checking-element-types), and they provide easy workarounds to solve these reference issues.

Thanks again for the awesome work on adding support for React 16!