### PR TITLE
fix(menu): add support for react-hot-loader by comparing cached rende…

### DIFF
--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -17,6 +17,8 @@ const POSITION = {
 };
 
 const factory = (MenuItem) => {
+  const MenuItemType = <MenuItem />.type;
+
   class Menu extends Component {
     static propTypes = {
       active: PropTypes.bool,
@@ -187,7 +189,7 @@ const factory = (MenuItem) => {
     renderItems () {
       return React.Children.map(this.props.children, (item) => {
         if (!item) return item;
-        if (item.type === MenuItem) {
+        if (item.type === MenuItemType) {
           return React.cloneElement(item, {
             ripple: item.props.ripple || this.props.ripple,
             selected: typeof item.props.value !== 'undefined' && this.props.selectable && item.props.value === this.props.selected,


### PR DESCRIPTION
…red types

As encountered by @mgcrea on the pull request #2, I fixed the same bug due to **react-hot-loader@^4.3.3** on Menu component

And thanks a lot for adding support on React 16 ! :-)